### PR TITLE
LRIS-31786 add gtm code to theme

### DIFF
--- a/src/resources/templates/document_head.hbs
+++ b/src/resources/templates/document_head.hbs
@@ -1,3 +1,11 @@
 <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport" />
 
 <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,400i,600,700|Source+Serif+Pro" rel="stylesheet">
+
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-K6TP58G');</script>
+<!-- End Google Tag Manager -->

--- a/src/resources/templates/header.hbs
+++ b/src/resources/templates/header.hbs
@@ -1,3 +1,8 @@
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K6TP58G"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+
 <svg display="none" height="0" version="1.1" width="0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 	<symbol id="analytics-cloud-logo" viewBox="0 0 28 28">
 		<g transform="translate(-7 -6)" fill="none"><rect width="40" height="40"/><path d="M17.066 20.4c.728 0 1.334.593 1.334 1.304v10.192c0 .711-.606 1.304-1.334 1.304H8.534c-.728 0-1.334-.593-1.334-1.304V21.704c0-.711.606-1.304 1.334-1.304h8.532zM33.066 13.2c.728 0 1.334.57 1.334 1.255v17.49c0 .685-.606 1.255-1.334 1.255h-8.532c-.728 0-1.334-.57-1.334-1.255v-17.49c0-.685.606-1.255 1.334-1.255h8.532z" fill="#0791D6"/><path d="M25.066 6.8c.728 0 1.334.567 1.334 1.248v23.904c0 .68-.606 1.248-1.334 1.248h-8.532c-.727 0-1.334-.567-1.334-1.248V8.048c0-.68.607-1.248 1.334-1.248h8.532z" fill="#0B63CE"/><path d="M15.241 20.4h1.805s1.354-.078 1.354 1.461v10.263s0 1.066-1.6 1.066c0 0-1.354.197-1.6-1.145V20.401h.041zM24.554 13.2s-1.354-.075-1.354 1.407V32.164s0 1.026 1.6 1.026c0 0 1.354.19 1.6-1.102V13.201h-1.846z" fill="#0F37A7"/></g>


### PR DESCRIPTION
Hey @jonmak08,
 
https://issues.liferay.com/browse/LRIS-31786 adds GTM to the Zendesk Theme, which surfaces a few things that need to be ironed out. I listed them in https://issues.liferay.com/browse/LRIS-32059. 

Basically, it would be a lot less error prone if there is a process to spin up a production bundle and an uat bundle, each with some unique code diff. For example, production bundle would have the GTM code, uat wouldn't. Each environment bundle footer would link to the respective category with the accurate id, etc. 

There also needs to be a way to safely store the API keys without exposing them on git. 

I looked into integrating with Travis-ci for a little bit, but I wasn't sure if this repo will stay here or not. Let me know if you have any ideas on how I can approach this. 

Thanks!

